### PR TITLE
Client can now handle gzip posts.

### DIFF
--- a/src/HttpMockSlim/Extensions/StreamExtensions.cs
+++ b/src/HttpMockSlim/Extensions/StreamExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.IO.Compression;
 using System.Text;
 
 namespace HttpMockSlim.Extensions
@@ -21,6 +22,23 @@ namespace HttpMockSlim.Extensions
             {
                 return reader.ReadToEnd();
             }
+        }
+
+        /// <summary>
+        /// Decompress a GZip stream and return the content as a string
+        /// </summary>
+        /// <param name="stream">Compressed stream</param>
+        /// <returns>Content of the compressed stream</returns>
+        public static string DecompressStream(this Stream stream)
+        {
+            var buffer = new byte[1024];
+
+            using (GZipStream gZipStream = new GZipStream(stream, CompressionMode.Decompress))
+            {
+                gZipStream.Read(buffer, 0, buffer.Length);
+            }
+
+            return Encoding.UTF8.GetString(buffer);
         }
     }
 }

--- a/src/HttpMockSlim/Handlers/SimpleFuncHandler.cs
+++ b/src/HttpMockSlim/Handlers/SimpleFuncHandler.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.IO;
+using System.IO.Compression;
 using System.Net;
+using System.Text;
+using HttpMockSlim.Extensions;
 using HttpMockSlim.Model;
 
 namespace HttpMockSlim.Handlers
@@ -45,7 +48,8 @@ namespace HttpMockSlim.Handlers
                 using (Stream body = clientRequest.InputStream)
                 using (StreamReader reader = new StreamReader(body, clientRequest.ContentEncoding))
                 {
-                    result.Body = reader.ReadToEnd();
+                    string content = clientRequest.Headers["Content-Encoding"];
+                    result.Body = content == "gzip" ? reader.BaseStream.DecompressStream() : reader.ReadToEnd();
                 }
             }
 


### PR DESCRIPTION
This pull request enables the passing of a gzip compressed body to the server and instead of trying to assign the compressed data to the string the server will instead decompress it and then assign the decompressed data to the body. This allow testing clients where you have no way to control if the data is compressed or not.

- Added method to decompress gzip streams (body)
- SimpleFuncHandler now checks to see if the content body uses gzip compression and if it does pass it for decompression before adding it to the result body